### PR TITLE
Add support for generating AppImage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ dalamud/
 ffxiv_dx11_d3d11.log
 /appimage-docker/output/microlaunch-x86_64.AppImage
 /appimage-docker/steamworks_sdk
-/appimage-docker/cargo_cache
+/appimage-docker/cache
 /appimage-docker/output

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@ private/
 dalamud/
 ffxiv_dx11_d3d11.log
 /appimage-docker/output/microlaunch-x86_64.AppImage
-/appimage-docker/steamworks_sdk/*
-/appimage-docker/cargo_cache/target/*
-/appimage-docker/cargo_cache/registry/*
+/appimage-docker/steamworks_sdk
+/appimage-docker/cargo_cache
+/appimage-docker/output

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ sqexcrypt/*.txt
 private/
 dalamud/
 ffxiv_dx11_d3d11.log
+/appimage-docker/output/microlaunch-x86_64.AppImage
+/appimage-docker/steamworks_sdk/*
+/appimage-docker/cargo_cache/target/*
+/appimage-docker/cargo_cache/registry/*

--- a/appimage-docker/APPIMAGE.md
+++ b/appimage-docker/APPIMAGE.md
@@ -1,0 +1,6 @@
+# Building an AppImage for microlaunch
+- **Follow the steps for cloning submodules in BUILDING.md**
+- Ensure docker is installed and set up correctly.
+- Put the `sdk` folder of the Steamworks SDK into `steamworks_sdk/`.
+- Run `build-appimage.sh` from `appimage-docker` directory.
+- If nothing goes wrong, `microlaunch-x86_64.AppImage` should appear in `output/`.

--- a/appimage-docker/APPIMAGE.md
+++ b/appimage-docker/APPIMAGE.md
@@ -1,6 +1,6 @@
 # Building an AppImage for microlaunch
 - **Follow the steps for cloning submodules in BUILDING.md**
 - Ensure docker is installed and set up correctly.
-- Put the `sdk` folder of the Steamworks SDK into `steamworks_sdk/`.
+- Put the `sdk` folder of the Steamworks SDK into `appimage-docker/steamworks_sdk/`.
 - Run `build-appimage.sh` from `appimage-docker` directory.
-- If nothing goes wrong, `microlaunch-x86_64.AppImage` should appear in `output/`.
+- If nothing goes wrong, `microlaunch-x86_64.AppImage` should appear in `appimage-docker/output/`.

--- a/appimage-docker/APPIMAGE.md
+++ b/appimage-docker/APPIMAGE.md
@@ -2,5 +2,5 @@
 - **Follow the steps for cloning submodules in BUILDING.md**
 - Ensure docker is installed and set up correctly.
 - Put the `sdk` folder of the Steamworks SDK into `appimage-docker/steamworks_sdk/`.
-- Run `build-appimage.sh` from `appimage-docker` directory.
+- Run `build-appimage.sh` in `appimage-docker` directory.
 - If nothing goes wrong, `microlaunch-x86_64.AppImage` should appear in `appimage-docker/output/`.

--- a/appimage-docker/assets/AppRun
+++ b/appimage-docker/assets/AppRun
@@ -1,0 +1,5 @@
+#!/bin/bash
+HERE="$(dirname "$(readlink -f "${0}")")"
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HERE/usr/lib/
+exec $HERE/usr/bin/microlaunch "$@"
+

--- a/appimage-docker/assets/AppRun
+++ b/appimage-docker/assets/AppRun
@@ -1,5 +1,6 @@
 #!/bin/bash
-HERE="$(dirname "$(readlink -f "${0}")")"
+HERE="$(dirname "$(readlink -f "${0}")")" # Find out where we are.
+# Use LD_LIBRARY_PATH instead of patching the binary. Needed to load libsteam_api.so .
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HERE/usr/lib/
 exec $HERE/usr/bin/microlaunch "$@"
 

--- a/appimage-docker/assets/microlaunch.desktop
+++ b/appimage-docker/assets/microlaunch.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Exec=AppRun
+Name=microlaunch
+Categories=Game
+Icon=icon
+

--- a/appimage-docker/build-appimage.sh
+++ b/appimage-docker/build-appimage.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+run_container() {
+    sudo docker run \
+    -v $PWD/../:/root/microlaunch/ \
+    -v $PWD/cargo_cache/target/:/root/microlaunch/target \
+    -v $PWD/cargo_cache/registry/:/usr/local/cargo/registry \
+    microlaunch-docker
+}
+
+if sudo docker image inspect microlaunch-docker:latest ; [ "$?" -eq 0 ];
+then
+    run_container
+else
+    if cd docker && sudo docker build -t microlaunch-docker:latest . ; [ "$?" -eq 0 ];   
+    then
+        cd ../ && run_container
+    else
+        echo "Something went wrong building the cotainer, please inspect the output."
+        exit 1
+    fi
+fi
+    
+
+

--- a/appimage-docker/build-appimage.sh
+++ b/appimage-docker/build-appimage.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-
+HERE="$(dirname "$(readlink -f "${0}")")" # Find out where we are.
 # Make sure required directories exist.
-mkdir -p $PWD/output/
-mkdir -p $PWD/cargo_cache/target
-mkdir -p $PWD/cargo_cache/registry
+mkdir -p $HERE/output/
+mkdir -p $HERE/cargo_cache/target
+mkdir -p $HERE/cargo_cache/registry
 
 # As for the three volumes defined below:
 # 1. Mount the source tree into the container for direct usage.
@@ -11,9 +11,9 @@ mkdir -p $PWD/cargo_cache/registry
 # 3. Mount a local directory for cargo registry cache, this will probably break at some point?
 run_container() {
     sudo docker run \
-    -v $PWD/../:/root/microlaunch/ \
-    -v $PWD/cargo_cache/target/:/root/microlaunch/target \
-    -v $PWD/cargo_cache/registry/:/usr/local/cargo/registry \
+    -v $HERE/../:/root/microlaunch/ \
+    -v $HERE/cargo_cache/target/:/root/microlaunch/target \
+    -v $HERE/cargo_cache/registry/:/usr/local/cargo/registry \
     microlaunch-docker
 }
 
@@ -24,7 +24,7 @@ then
 
 # If not, we build it, and check if build succeeds. (exit code 0)
 else
-    if cd docker && sudo docker build -t microlaunch-docker:latest . ; [ "$?" -eq 0 ];
+    if cd $HERE/docker && sudo docker build -t microlaunch-docker:latest . ; [ "$?" -eq 0 ];
     then
         cd ../ && run_container
     else
@@ -32,6 +32,3 @@ else
         exit 1
     fi
 fi
-    
-
-

--- a/appimage-docker/build-appimage.sh
+++ b/appimage-docker/build-appimage.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-mkdir -p $PWD/output/ # Make sure output directory exists.
+# Make sure required directories exist.
+mkdir -p $PWD/output/
+mkdir -p $PWD/cargo_cache/target
+mkdir -p $PWD/cargo_cache/registry
 
 # As for the three volumes defined below:
 # 1. Mount the source tree into the container for direct usage.

--- a/appimage-docker/build-appimage.sh
+++ b/appimage-docker/build-appimage.sh
@@ -7,8 +7,8 @@
 run_container() {
     sudo docker run \
     -v $PWD/../:/root/microlaunch/ \
-    -v $PWD/cargo_cache/target/:/root/microlaunch/target \ 
-    -v $PWD/cargo_cache/registry/:/usr/local/cargo/registry \ 
+    -v $PWD/cargo_cache/target/:/root/microlaunch/target \
+    -v $PWD/cargo_cache/registry/:/usr/local/cargo/registry \
     microlaunch-docker
 }
 

--- a/appimage-docker/build-appimage.sh
+++ b/appimage-docker/build-appimage.sh
@@ -1,17 +1,25 @@
 #!/bin/bash
+
+# As for the three volumes defined below:
+# 1. Mount the source tree into the container for direct usage.
+# 2. Mount a local directoy for cargo build cache, so we can reuse it.
+# 3. Mount a local directory for cargo registry cache, this will probably break at some point?
 run_container() {
     sudo docker run \
     -v $PWD/../:/root/microlaunch/ \
-    -v $PWD/cargo_cache/target/:/root/microlaunch/target \
-    -v $PWD/cargo_cache/registry/:/usr/local/cargo/registry \
+    -v $PWD/cargo_cache/target/:/root/microlaunch/target \ 
+    -v $PWD/cargo_cache/registry/:/usr/local/cargo/registry \ 
     microlaunch-docker
 }
 
+# Check if microlaunch-dcker container already exists. (exit code 0)
 if sudo docker image inspect microlaunch-docker:latest ; [ "$?" -eq 0 ];
 then
     run_container
+
+# If not, we build it, and check if build succeeds. (exit code 0)
 else
-    if cd docker && sudo docker build -t microlaunch-docker:latest . ; [ "$?" -eq 0 ];   
+    if cd docker && sudo docker build -t microlaunch-docker:latest . ; [ "$?" -eq 0 ];
     then
         cd ../ && run_container
     else

--- a/appimage-docker/build-appimage.sh
+++ b/appimage-docker/build-appimage.sh
@@ -8,6 +8,7 @@ mkdir -p $HERE/cache/
 # 1. Mount the source tree into the container for direct usage.
 # 2. Mount a local directoy for cargo build cache, so we can reuse it.
 # 3. Mount a local directory for cargo registry cache, this will probably break at some point?
+# Parameter is for optionally passing environment variables to build.sh script. Used for clean command.
 run_container() {
     sudo docker run \
     -v $HERE/../:/root/microlaunch/ \
@@ -58,7 +59,7 @@ rebuild-container   -   Rebuild docker container, ignoring build cache."
 case $1 in
     rebuild-container)  rebuild_container ;;
     update-container)   build_container;;
-    clean)              run_container "-e PARAMETER=clean" ;;
+    clean)              run_container "-e PARAMETER=clean" ;; # Environment variable is used in build.sh.
     help)               print_help ;;
     "")                 check_container ;;
     *)                  echo "Use 'help' to print help. Terminating!" ;;

--- a/appimage-docker/build-appimage.sh
+++ b/appimage-docker/build-appimage.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+mkdir -p $PWD/output/ # Make sure output directory exists.
+
 # As for the three volumes defined below:
 # 1. Mount the source tree into the container for direct usage.
 # 2. Mount a local directoy for cargo build cache, so we can reuse it.

--- a/appimage-docker/docker/Dockerfile
+++ b/appimage-docker/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM rust:buster
+
+# Install dependencies.
+RUN apt update -y && apt upgrade -y && \
+apt install -y libxcb-composite0-dev 
+
+# Download and set up appimagetool
+RUN wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /opt/appimagetool && \
+cd /opt/; chmod +x appimagetool; sed -i 's|AI\x02|\x00\x00\x00|' appimagetool; ./appimagetool --appimage-extract && \
+mv /opt/squashfs-root /opt/appimagetool.AppDir && \
+ln -s /opt/appimagetool.AppDir/AppRun /usr/local/bin/appimagetool
+
+# Set up AppDir structure.
+WORKDIR /root/AppDir/
+RUN mkdir -p usr/bin && \
+mkdir -p usr/lib
+
+# Copy build script, set entry point.
+WORKDIR /root/
+COPY build.sh build.sh
+CMD ./build.sh

--- a/appimage-docker/docker/build.sh
+++ b/appimage-docker/docker/build.sh
@@ -1,17 +1,37 @@
 #!/bin/bash
 SRC=/root/microlaunch
 APPDIR=/root/AppDir
-cd $SRC
-STEAM_SDK_LOCATION=$SRC/appimage-docker/steamworks_sdk/sdk cargo b --release # Build it!
-# Copy files required for AppImage.
-cd $SRC/appimage-docker/assets/
-cp AppRun $APPDIR/
-cp microlaunch.desktop $APPDIR/
-cp icon.png $APPDIR/
-cp $SRC/target/release/microlaunch $APPDIR/usr/bin/
-# We have to include libsteam_api.so for microlaunch to work, so we look for it.
-FP=`find $SRC/target/release/ -name libsteam_api.so`
-cp $FP $APPDIR/usr/lib/
-cd /root/
-appimagetool $APPDIR
-cp microlaunch-x86_64.AppImage $SRC/appimage-docker/output/
+export CARGO_TARGET_DIR=/root/cache/target
+export STEAM_SDK_LOCATION=$SRC/appimage-docker/steamworks_sdk/sdk 
+
+build_binary() {
+    cd $SRC
+    cargo b --release # Build it!
+}
+cargo_clean() {
+    cd $SRC
+    cargo clean
+}
+build_appimage(){
+    # Copy files required for AppImage.
+    cd $SRC/appimage-docker/assets/
+    cp AppRun $APPDIR/
+    cp microlaunch.desktop $APPDIR/
+    cp icon.png $APPDIR/
+    cp $CARGO_TARGET_DIR/release/microlaunch $APPDIR/usr/bin/
+    # We have to include libsteam_api.so for microlaunch to work, so we look for it.
+    FP=`find $CARGO_TARGET_DIR/release/ -name libsteam_api.so`
+    cp $FP $APPDIR/usr/lib/
+    cd /root/
+    appimagetool $APPDIR
+    cp microlaunch-x86_64.AppImage $SRC/appimage-docker/output/
+}
+build() {
+    build_binary
+    build_appimage
+}
+
+case $PARAMETER in
+    clean)  cargo_clean ;;
+    *)      build ;;
+esac

--- a/appimage-docker/docker/build.sh
+++ b/appimage-docker/docker/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 SRC=/root/microlaunch
 APPDIR=/root/AppDir
+# Change cargo target directory so we can delete it from inside the container, but keep it outside the container.
 export CARGO_TARGET_DIR=/root/cache/target
 export STEAM_SDK_LOCATION=$SRC/appimage-docker/steamworks_sdk/sdk 
 
@@ -31,6 +32,7 @@ build() {
     build_appimage
 }
 
+# $PARAMTER is passed in as environment variable from build-appimage.sh
 case $PARAMETER in
     clean)  cargo_clean ;;
     *)      build ;;

--- a/appimage-docker/docker/build.sh
+++ b/appimage-docker/docker/build.sh
@@ -12,5 +12,6 @@ cp $SRC/target/release/microlaunch $APPDIR/usr/bin/
 # We have to include libsteam_api.so for microlaunch to work, so we look for it.
 FP=`find $SRC/target/release/ -name libsteam_api.so`
 cp $FP $APPDIR/usr/lib/
+cd /root/
 appimagetool $APPDIR
 cp microlaunch-x86_64.AppImage $SRC/appimage-docker/output/

--- a/appimage-docker/docker/build.sh
+++ b/appimage-docker/docker/build.sh
@@ -2,12 +2,14 @@
 SRC=/root/microlaunch
 APPDIR=/root/AppDir
 cd $SRC
-STEAM_SDK_LOCATION=$SRC/appimage-docker/steamworks_sdk/sdk cargo b --release
+STEAM_SDK_LOCATION=$SRC/appimage-docker/steamworks_sdk/sdk cargo b --release # Build it!
+# Copy files required for AppImage.
 cd $SRC/appimage-docker/assets/
 cp AppRun $APPDIR/
 cp microlaunch.desktop $APPDIR/
 cp icon.png $APPDIR/
 cp $SRC/target/release/microlaunch $APPDIR/usr/bin/
+# We have to include libsteam_api.so for microlaunch to work, so we look for it.
 FP=`find $SRC/target/release/ -name libsteam_api.so`
 cp $FP $APPDIR/usr/lib/
 appimagetool $APPDIR

--- a/appimage-docker/docker/build.sh
+++ b/appimage-docker/docker/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+SRC=/root/microlaunch
+APPDIR=/root/AppDir
+cd $SRC
+STEAM_SDK_LOCATION=$SRC/appimage-docker/steamworks_sdk/sdk cargo b --release
+cd $SRC/appimage-docker/assets/
+cp AppRun $APPDIR/
+cp microlaunch.desktop $APPDIR/
+cp icon.png $APPDIR/
+cp $SRC/target/release/microlaunch $APPDIR/usr/bin/
+FP=`find $SRC/target/release/ -name libsteam_api.so`
+cp $FP $APPDIR/usr/lib/
+appimagetool $APPDIR
+cp microlaunch-x86_64.AppImage $SRC/appimage-docker/output/


### PR DESCRIPTION
This adds a docker based build environment for generating an AppImage.
Management scripts for easy usage are included.

This mounts the current source tree into the container, so in theory it could mess things up.
How ever the only things being run are "cargo build" and "cargo clean"
And the target directory is purposefully kept separate from host.

### Current state and caveats:

It is based on the rust:buster image. The Ubuntu 18.04 image (oldest Ubuntu supported version) comes with a cmake version too old to build one of this projects dependencies.
.desktop file is rather barren.
The icon file is an empty placeholder
I am not sure if i am handling things correctly in the AppRun script.
I have not specifically tested this on a system with absolutely minimal dependencies.
It does work on Steam Deck, which i would consider the main use of this.

